### PR TITLE
fix: correct user paths for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,4 +18,4 @@ jobs:
           playbook: ansible-playbook/deploy.yml
           inventory: ansible-playbook/inventory.ini
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_user: user
+          remote_user: mathis.oudin-gcp

--- a/ansible-playbook/deploy.yml
+++ b/ansible-playbook/deploy.yml
@@ -10,7 +10,7 @@
     - name: Arrêter l'ancienne application PM2
       shell: pm2 delete test-ansible-nextjs || true
       args:
-        chdir: /home/user
+        chdir: /home/mathis.oudin-gcp
       ignore_errors: yes
 
     - name: Tuer tous les processus Node.js sur le port 3000
@@ -22,7 +22,7 @@
     - name: Cloner le projet
       git:
         repo: 'https://github.com/grintzdel/test-ansible-nextjs.git'
-        dest: /home/user/test-ansible-nextjs
+        dest: /home/mathis.oudin-gcp/test-ansible-nextjs
         version: main
         update: yes
         force: yes
@@ -30,24 +30,24 @@
     - name: Installer les dépendances
       command: npm install
       args:
-        chdir: /home/user/test-ansible-nextjs
+        chdir: /home/mathis.oudin-gcp/test-ansible-nextjs
 
     - name: Générer le build
       command: npm run build
       args:
-        chdir: /home/user/test-ansible-nextjs
+        chdir: /home/mathis.oudin-gcp/test-ansible-nextjs
 
     - name: Lancer Next.js avec PM2
       shell: pm2 start npm --name test-ansible-nextjs -- start
       args:
-        chdir: /home/user/test-ansible-nextjs
+        chdir: /home/mathis.oudin-gcp/test-ansible-nextjs
 
     - name: Sauvegarder la configuration PM2
       command: pm2 save
       args:
-        chdir: /home/user/test-ansible-nextjs
+        chdir: /home/mathis.oudin-gcp/test-ansible-nextjs
 
     - name: Configurer PM2 pour démarrer au boot
-      shell: pm2 startup systemd -u user --hp /home/user || true
+      shell: pm2 startup systemd -u mathis.oudin-gcp --hp /home/mathis.oudin-gcp || true
       become: yes
       ignore_errors: yes

--- a/ansible-playbook/inventory.ini
+++ b/ansible-playbook/inventory.ini
@@ -2,6 +2,6 @@
 34.39.56.246
 
 [webserver:vars]
-ansible_user=user
+ansible_user=mathis.oudin-gcp
 ansible_ssh_private_key_file=~/.ssh/gcp_nextjs
 ansible_python_interpreter=/usr/bin/python3

--- a/check-server.sh
+++ b/check-server.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Script de diagnostic du serveur
+
+SERVER="34.39.56.246"
+USER="mathis.oudin-gcp"
+KEY="~/.ssh/gcp_nextjs"
+
+echo "🔍 DIAGNOSTIC DU SERVEUR $SERVER"
+echo "=================================="
+echo ""
+
+ssh -i $KEY $USER@$SERVER << 'ENDSSH'
+
+echo "📁 1. Recherche de l'application..."
+echo "-----------------------------------"
+find /home -name "test-ansible-nextjs" -type d 2>/dev/null || echo "❌ Dossier test-ansible-nextjs non trouvé"
+find /home -name "*nextjs*" -type d 2>/dev/null || echo "❌ Aucun dossier nextjs trouvé"
+find /home -name "app" -type d 2>/dev/null || echo "❌ Aucun dossier app trouvé"
+
+echo ""
+echo "👤 2. Utilisateurs disponibles..."
+echo "-----------------------------------"
+ls -la /home/
+
+echo ""
+echo "📦 3. Processus PM2..."
+echo "-----------------------------------"
+pm2 list
+pm2 status
+
+echo ""
+echo "🔌 4. Ports en écoute..."
+echo "-----------------------------------"
+netstat -tuln | grep LISTEN | grep -E "(3000|80|443)" || echo "❌ Aucun port web en écoute"
+
+echo ""
+echo "⚙️  5. Node.js et NPM..."
+echo "-----------------------------------"
+which node
+node --version || echo "❌ Node.js non installé"
+which npm
+npm --version || echo "❌ NPM non installé"
+which pm2
+pm2 --version || echo "❌ PM2 non installé"
+
+echo ""
+echo "📝 6. Processus Node.js actifs..."
+echo "-----------------------------------"
+ps aux | grep node | grep -v grep || echo "❌ Aucun processus Node.js"
+
+echo ""
+echo "🌐 7. Variables d'environnement utilisateur..."
+echo "-----------------------------------"
+echo "USER: $USER"
+echo "HOME: $HOME"
+echo "PWD: $PWD"
+
+ENDSSH
+
+echo ""
+echo "✅ Diagnostic terminé !"

--- a/cleanup-server.sh
+++ b/cleanup-server.sh
@@ -3,7 +3,7 @@
 # Script de nettoyage rapide du serveur
 
 SERVER="34.39.56.246"
-USER="user"
+USER="mathis.oudin-gcp"
 KEY="~/.ssh/gcp_nextjs"
 
 echo "🧹 Nettoyage du serveur $SERVER..."


### PR DESCRIPTION
Changes:
- Fix ansible_user from 'user' to 'mathis.oudin-gcp' in inventory.ini
- Update all paths from /home/user/ to /home/mathis.oudin-gcp/
- Update remote_user in GitHub Actions deploy workflow
- Fix cleanup-server.sh and check-server.sh scripts
- Add check-server.sh diagnostic script

Application location on server:
/home/mathis.oudin-gcp/test-ansible-nextjs

npm start command is executed via PM2:
pm2 start npm --name test-ansible-nextjs -- start